### PR TITLE
Adding JSON-sending back into the library

### DIFF
--- a/src/ros_topic.cpp
+++ b/src/ros_topic.cpp
@@ -151,7 +151,8 @@ namespace rosbridge2cpp {
 		cmd.msg_json_ = message;
 		cmd.latch_ = latch_;
 
-		return ros_.QueueMessage(topic_name_, queue_size_, cmd);
+		//Queue is not implemented for JSON
+		return ros_.SendMessage(cmd);
 	}
 
 	bool ROSTopic::Publish(bson_t *message)


### PR DESCRIPTION
In the implementation from the ROSIntegration Repo the JSON sending was broken. With this, it is added back, skipping the message queuing