### PR TITLE
fix cmakelists.txt to build on Ubuntu 20.04 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@
 
 
 cmake_minimum_required(VERSION 2.8)
+set(PROJECT_NAME rosbridge2cpp)
+project(${PROJECT_NAME})
+
 option(test "Build all tests." OFF) # Makes boolean 'test' available.
 
 find_package(PkgConfig QUIET)
@@ -21,10 +24,9 @@ else()
 	set(LIBBSON_LIBRARIES "bson-static-1.0.lib" CACHE STRING "Lib file. Different between platforms")
 endif()
 
-set(PROJECT_NAME rosbridge2cpp)
-project(${PROJECT_NAME})
-
 if(NOT WIN32)
+	find_package(Threads)
+	set(LIBS ${LIBS} ${CMAKE_THREAD_LIBS_INIT})	
 	set(CMAKE_CXX_FLAGS "-g -Wall")
 endif()
 


### PR DESCRIPTION
Hello, @Sanic 

This commit fix 2 issues when compiling on Ubuntu 20.04.

1. Project is not set before find_package. CMake complains that "CMake Error: Error required internal CMake variable not set, cmake may not be built correctly. Missing variable is: CMAKE_FIND_LIBRARY_PREFIXES"
2. libpthread is used in the implementation of std::thread in gcc/clang. libpthread needs to be added as a link library in non-Windows env.