### PR TITLE
add Virtual deconstructor for ITransportLayer in itransport_layer.h

### DIFF
--- a/include/itransport_layer.h
+++ b/include/itransport_layer.h
@@ -14,6 +14,7 @@ namespace rosbridge2cpp {
 	class ITransportLayer {
 	public:
 		enum TransportMode { JSON, BSON };
+		virtual ~ITransportLayer() = default;
 
 		// Initialize the TransportLayer by connecting to the given IP and port
 		// The implementing class should have an active connection to IP:port


### PR DESCRIPTION
add Virtual deconstructor for ITransportLayer, fixes "error: delete called on non-final 'TCPConnection' that has virtual functions but non-virtual" when building for UE 5.2